### PR TITLE
World cup init

### DIFF
--- a/lib/world_cup.rb
+++ b/lib/world_cup.rb
@@ -1,0 +1,19 @@
+class WorldCup
+  attr_reader :year, :teams
+
+  def initialize(year, teams)
+    @year = year
+    @teams = teams
+  end
+
+  def active_players_by_position(position)
+    all_players = []
+    @teams.each do |team|
+      unless team.eliminated?
+        all_players << team.players_by_position(position)
+      end
+    end
+    all_players.flatten
+  end
+
+end

--- a/test/world_cup_test.rb
+++ b/test/world_cup_test.rb
@@ -1,0 +1,39 @@
+require 'minitest/autorun'
+require 'minitest/pride'
+require '../lib/player'
+require '../lib/team'
+require '../lib/world_cup'
+class WorldCupTest < Minitest::Test
+  def setup
+    @mbappe = Player.new({name: "Kylian Mbappe", position: "forward"})
+    @pogba = Player.new({name: "Paul Pogba", position: "midfielder"})
+    @france = Team.new("France")
+    @france.add_player(@mbappe)
+    @france.add_player(@pogba)
+    @croatia = Team.new("Croatia")
+    @modric = Player.new({name: "Luka Modric", position: "midfielder"})
+    @vida = Player.new({name: "Domagoj Vida", position: "defender"})
+    @croatia.add_player(@modric)
+    @croatia.add_player(@vida)
+    @world_cup = WorldCup.new(2018, [@france, @croatia])
+  end
+
+  def test_it_exists
+    assert_instance_of WorldCup, @world_cup
+  end
+
+  def test_it_has_argument_attributes
+    assert_equal 2018, @world_cup.year
+    assert_equal [@france, @croatia], @world_cup.teams
+  end
+
+  def test_it_can_return_all_active_players_per_position
+    assert_equal [@pogba, @modric], @world_cup.active_players_by_position("midfielder")
+  end
+
+  def test_it_returns_only_active_players_per_position
+    @croatia.eliminated = true
+
+    assert_equal [@pogba], @world_cup.active_players_by_position("midfielder")
+  end
+end


### PR DESCRIPTION
This PR adds the World Cup class with tests outlining the base functionality of the class. Currently, it takes in a integer of the Year of the World Cup, and an array of Teams that are participating.
These teams can then be accessed by the Active Players By Position method. This will iterate through them, using each Teams already existing Players by Position method to store all of them in a new array. This array is then flattened for final output. The WorldCup method also only searches Teams who are marked false for Eliminated.